### PR TITLE
Reworking event API 

### DIFF
--- a/common/package-lock.json
+++ b/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@data-heaving/common",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@data-heaving/common",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "14.14.31",

--- a/common/package.json
+++ b/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-heaving/common",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "author": {
     "name": "Stanislav Muhametsin",
     "email": "346799+stazz@users.noreply.github.com",


### PR DESCRIPTION
Reworking event API not to cause compile-time error for common usecase. Also adding code to events.spec.ts to validate it will not break again in the future.