### PR TITLE
Release of the components sql, test-support and validation to version 1.0.0

### DIFF
--- a/sql/package-lock.json
+++ b/sql/package-lock.json
@@ -1,17 +1,15 @@
 {
   "name": "@data-heaving/common-sql",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@data-heaving/common-sql",
-      "version": "0.10.2",
+      "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "@data-heaving/common": "0.10.1"
-      },
       "devDependencies": {
+        "@data-heaving/common": "^1.0.0",
         "@types/node": "14.14.31",
         "@typescript-eslint/eslint-plugin": "4.22.0",
         "@typescript-eslint/parser": "4.22.0",
@@ -22,6 +20,9 @@
         "nyc": "15.1.0",
         "prettier": "2.2.1",
         "typescript": "4.2.4"
+      },
+      "peerDependencies": {
+        "@data-heaving/common": "^1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -490,9 +491,10 @@
       }
     },
     "node_modules/@data-heaving/common": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@data-heaving/common/-/common-0.10.1.tgz",
-      "integrity": "sha512-WmAjhu5oQGmAyPwAf7GdA4Bom3SL6fyUCWcNNiPhPjQnXSIaX5O4jQoLU+hiGfPOlx6k/U+ecA9o5HSZQ3dUAw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@data-heaving/common/-/common-1.0.0.tgz",
+      "integrity": "sha512-7M8pYplSZayHkbB9GRHCwUqgFacKb2S86xod4Xk6LsrG71giwikleWJxsos+JoFuyVfSEnE/6uSEGXLj0K6VyQ==",
+      "dev": true
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.1",
@@ -5476,9 +5478,10 @@
       "dev": true
     },
     "@data-heaving/common": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@data-heaving/common/-/common-0.10.1.tgz",
-      "integrity": "sha512-WmAjhu5oQGmAyPwAf7GdA4Bom3SL6fyUCWcNNiPhPjQnXSIaX5O4jQoLU+hiGfPOlx6k/U+ecA9o5HSZQ3dUAw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@data-heaving/common/-/common-1.0.0.tgz",
+      "integrity": "sha512-7M8pYplSZayHkbB9GRHCwUqgFacKb2S86xod4Xk6LsrG71giwikleWJxsos+JoFuyVfSEnE/6uSEGXLj0K6VyQ==",
+      "dev": true
     },
     "@eslint/eslintrc": {
       "version": "0.4.1",

--- a/sql/package.json
+++ b/sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-heaving/common-sql",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "author": {
     "name": "Stanislav Muhametsin",
     "email": "346799+stazz@users.noreply.github.com",
@@ -21,10 +21,11 @@
     "remove-test-files": "rm -rf dist/*/tests",
     "format-output-files": "echo 'const config = require(\"./.eslintrc\"); config.parserOptions.createDefaultProgram = true; config.settings = { [\"import/resolver\"]: { node: { paths: [\"dist\"], extensions: [\".d.ts\"] } } }; console.log(JSON.stringify(config));' | node > .eslintrc-publish.json && eslint --no-eslintrc --config '.eslintrc-publish.json' --fix --ext '.d.ts' dist; FOF_RC=$?; rm -f '.eslintrc-publish.json'; exit $FOF_RC"
   },
-  "dependencies": {
-    "@data-heaving/common": "0.10.1"
+  "peerDependencies": {
+    "@data-heaving/common": "^1.0.0"
   },
   "devDependencies": {
+    "@data-heaving/common": "^1.0.0",
     "@types/node": "14.14.31",
     "@typescript-eslint/eslint-plugin": "4.22.0",
     "@typescript-eslint/parser": "4.22.0",

--- a/test-support/package-lock.json
+++ b/test-support/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@data-heaving/common-test-support",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@data-heaving/common-test-support",
-      "version": "0.10.2",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@data-heaving/common": "0.12.0",
+        "@data-heaving/common": "^1.0.0",
         "@types/node": "14.14.31",
         "@typescript-eslint/eslint-plugin": "4.22.0",
         "@typescript-eslint/parser": "4.22.0",
@@ -480,9 +480,9 @@
       }
     },
     "node_modules/@data-heaving/common": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@data-heaving/common/-/common-0.12.0.tgz",
-      "integrity": "sha512-DBOvR5ySJaQPj8l4TU160L9bpvoasjIlzDXNrIg3kydLENi8vDNPjgHDUmBJjaKx7pa3oj2QB1wqv/fbDPNI8w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@data-heaving/common/-/common-1.0.0.tgz",
+      "integrity": "sha512-7M8pYplSZayHkbB9GRHCwUqgFacKb2S86xod4Xk6LsrG71giwikleWJxsos+JoFuyVfSEnE/6uSEGXLj0K6VyQ==",
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
@@ -5732,9 +5732,9 @@
       "dev": true
     },
     "@data-heaving/common": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@data-heaving/common/-/common-0.12.0.tgz",
-      "integrity": "sha512-DBOvR5ySJaQPj8l4TU160L9bpvoasjIlzDXNrIg3kydLENi8vDNPjgHDUmBJjaKx7pa3oj2QB1wqv/fbDPNI8w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@data-heaving/common/-/common-1.0.0.tgz",
+      "integrity": "sha512-7M8pYplSZayHkbB9GRHCwUqgFacKb2S86xod4Xk6LsrG71giwikleWJxsos+JoFuyVfSEnE/6uSEGXLj0K6VyQ==",
       "dev": true
     },
     "@eslint/eslintrc": {

--- a/test-support/package.json
+++ b/test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-heaving/common-test-support",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "author": {
     "name": "Stanislav Muhametsin",
     "email": "346799+stazz@users.noreply.github.com",
@@ -24,7 +24,7 @@
   "dependencies": {
   },
   "devDependencies": {
-    "@data-heaving/common": "0.12.0",
+    "@data-heaving/common": "^1.0.0",
     "@types/node": "14.14.31",
     "@typescript-eslint/eslint-plugin": "4.22.0",
     "@typescript-eslint/parser": "4.22.0",

--- a/validation/package-lock.json
+++ b/validation/package-lock.json
@@ -1,19 +1,15 @@
 {
   "name": "@data-heaving/common-validation",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@data-heaving/common-validation",
-      "version": "0.10.2",
+      "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "@data-heaving/common": "0.10.1",
-        "fp-ts": "2.9.5",
-        "io-ts": "2.2.15"
-      },
       "devDependencies": {
+        "@data-heaving/common": "^1.0.0",
         "@types/node": "14.14.31",
         "@typescript-eslint/eslint-plugin": "4.22.0",
         "@typescript-eslint/parser": "4.22.0",
@@ -21,9 +17,16 @@
         "eslint": "7.25.0",
         "eslint-config-prettier": "8.3.0",
         "eslint-plugin-prettier": "3.4.0",
+        "fp-ts": "^2.9.5",
+        "io-ts": "^2.2.15",
         "nyc": "15.1.0",
         "prettier": "2.2.1",
         "typescript": "4.2.4"
+      },
+      "peerDependencies": {
+        "@data-heaving/common": "^1.0.0",
+        "fp-ts": "^2.9.5",
+        "io-ts": "^2.2.15"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -510,9 +513,10 @@
       }
     },
     "node_modules/@data-heaving/common": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@data-heaving/common/-/common-0.10.1.tgz",
-      "integrity": "sha512-WmAjhu5oQGmAyPwAf7GdA4Bom3SL6fyUCWcNNiPhPjQnXSIaX5O4jQoLU+hiGfPOlx6k/U+ecA9o5HSZQ3dUAw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@data-heaving/common/-/common-1.0.0.tgz",
+      "integrity": "sha512-7M8pYplSZayHkbB9GRHCwUqgFacKb2S86xod4Xk6LsrG71giwikleWJxsos+JoFuyVfSEnE/6uSEGXLj0K6VyQ==",
+      "dev": true
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.1",
@@ -2370,6 +2374,7 @@
     },
     "node_modules/fp-ts": {
       "version": "2.9.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fromentries": {
@@ -2750,6 +2755,7 @@
     },
     "node_modules/io-ts": {
       "version": "2.2.15",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "fp-ts": "^2.0.0"
@@ -5601,9 +5607,10 @@
       "dev": true
     },
     "@data-heaving/common": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@data-heaving/common/-/common-0.10.1.tgz",
-      "integrity": "sha512-WmAjhu5oQGmAyPwAf7GdA4Bom3SL6fyUCWcNNiPhPjQnXSIaX5O4jQoLU+hiGfPOlx6k/U+ecA9o5HSZQ3dUAw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@data-heaving/common/-/common-1.0.0.tgz",
+      "integrity": "sha512-7M8pYplSZayHkbB9GRHCwUqgFacKb2S86xod4Xk6LsrG71giwikleWJxsos+JoFuyVfSEnE/6uSEGXLj0K6VyQ==",
+      "dev": true
     },
     "@eslint/eslintrc": {
       "version": "0.4.1",
@@ -6875,7 +6882,8 @@
       }
     },
     "fp-ts": {
-      "version": "2.9.5"
+      "version": "2.9.5",
+      "dev": true
     },
     "fromentries": {
       "version": "1.3.2",
@@ -7124,6 +7132,7 @@
     },
     "io-ts": {
       "version": "2.2.15",
+      "dev": true,
       "requires": {}
     },
     "irregular-plurals": {

--- a/validation/package.json
+++ b/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-heaving/common-validation",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "author": {
     "name": "Stanislav Muhametsin",
     "email": "346799+stazz@users.noreply.github.com",
@@ -21,12 +21,15 @@
     "remove-test-files": "rm -rf dist/*/tests",
     "format-output-files": "echo 'const config = require(\"./.eslintrc\"); config.parserOptions.createDefaultProgram = true; config.settings = { [\"import/resolver\"]: { node: { paths: [\"dist\"], extensions: [\".d.ts\"] } } }; console.log(JSON.stringify(config));' | node > .eslintrc-publish.json && eslint --no-eslintrc --config '.eslintrc-publish.json' --fix --ext '.d.ts' dist; FOF_RC=$?; rm -f '.eslintrc-publish.json'; exit $FOF_RC"
   },
-  "dependencies": {
-    "@data-heaving/common": "0.10.1",
-    "fp-ts": "2.9.5",
-    "io-ts": "2.2.15"
+  "peerDependencies": {
+    "@data-heaving/common": "^1.0.0",
+    "fp-ts": "^2.9.5",
+    "io-ts": "^2.2.15"
   },
   "devDependencies": {
+    "@data-heaving/common": "^1.0.0",
+    "fp-ts": "^2.9.5",
+    "io-ts": "^2.2.15",
     "@types/node": "14.14.31",
     "@typescript-eslint/eslint-plugin": "4.22.0",
     "@typescript-eslint/parser": "4.22.0",


### PR DESCRIPTION
Release of the components `sql`, `test-support` and `validation` to version `1.0.0`. Also changed direct dependencies to peer dependencies where they make sense.